### PR TITLE
Fix error when attempting to update a component that is unmounted

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -102,8 +102,11 @@ export default class TextField extends Component {
           duration: animationDuration,
           easing: Easing.inOut(Easing.ease),
         })
-        .start(() => {
-          this.setState((state, { error }) => ({ error }));
+        .start((completion) => {
+          if (completion.finished)
+          {
+            this.setState((state, { error }) => ({ error }));
+          }
         });
     }
   }


### PR DESCRIPTION
I was running into a crash when using the wix https://github.com/wix/react-native-navigation(react-navigation) library.  When a user submits their email address and password and presses Login I was seeing a crash due with the error "Attempted to update component `AnimatedComponent` that has already been unmounted (or failed to mount)".

I believe this error is caused by me starting a new "Tab based" navigation which throws away the current navigation stack.  This creates the error because the setState call attempts to update the component that is no longer mounted.  

Checking the "completion" handler in the animation "start" method to see if the animation "finished" seems to fix the issue for me.