### PR TITLE
Fix for Growing Multiline Inputs in RN > 0.40

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -292,6 +292,7 @@ export default class TextField extends PureComponent {
 
             editable={!disabled && editable}
             onChangeText={this.onChangeText}
+            onChange={this.onContentSizeChange}
             onContentSizeChange={this.onContentSizeChange}
             onFocus={this.onFocus}
             onBlur={this.onBlur}


### PR DESCRIPTION
In more recent version of RN, the onContentSizeChange is only called
with the initial size, and onChange is called thereafter.  This commit points the TextInput onChange listener to the same function as onContentSizeChange so that growing multiline inputs work again.  See
https://github.com/facebook/react-native/issues/6552#issuecomment-269989
962 & https://github.com/facebook/react-native/pull/1229#issuecomment-185462712