### PR TITLE
Removed Easing and allowed Animated.timing easing to default

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -4,7 +4,6 @@ import {
   View,
   TextInput,
   Animated,
-  Easing,
   StyleSheet,
   Platform,
 } from 'react-native';
@@ -125,7 +124,6 @@ export default class TextField extends PureComponent {
         .timing(focus, {
           toValue: props.error? -1 : (state.focused? 1 : 0),
           duration: animationDuration,
-          easing: Easing.inOut(Easing.ease),
         })
         .start(() => {
           if (this.mounted) {

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated, Easing } from 'react-native';
+import { Animated } from 'react-native';
 
 export default class Label extends PureComponent {
   static defaultProps = {
@@ -50,7 +50,6 @@ export default class Label extends PureComponent {
         .timing(input, {
           toValue: (props.active || props.focused)? 1 : 0,
           duration: animationDuration,
-          easing: Easing.inOut(Easing.ease),
         })
         .start();
     }
@@ -60,7 +59,6 @@ export default class Label extends PureComponent {
         .timing(focus, {
           toValue: props.errored? -1 : (props.focused? 1 : 0),
           duration: animationDuration,
-          easing: Easing.inOut(Easing.ease),
         })
         .start();
     }


### PR DESCRIPTION
In order to use this component in both react-native and
react-native-web, I removed the import of Easing and allowed the
timing’s easing property to default. The easing parameter defaults to
easeInOut, which isn't actually an option but is created like so: var
easeInOut = Easing.inOut(Easing.ease);