### PR TITLE
Pass event to onFocus and onBlur handlers

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -193,11 +193,11 @@ export default class TextField extends PureComponent {
     return characterRestriction < text.length;
   }
 
-  onFocus() {
+  onFocus(event) {
     let { onFocus } = this.props;
 
     if ('function' === typeof onFocus) {
-      onFocus();
+      onFocus(event);
     }
 
     this.setState({ focused: true, receivedFocus: true });

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -203,11 +203,11 @@ export default class TextField extends PureComponent {
     this.setState({ focused: true, receivedFocus: true });
   }
 
-  onBlur() {
+  onBlur(event) {
     let { onBlur } = this.props;
 
     if ('function' === typeof onBlur) {
-      onBlur();
+      onBlur(event);
     }
 
     this.setState({ focused: false });


### PR DESCRIPTION
This PR is made in order to get `event` in focus and blur handlers passed via props to `TextInput`