### PR TITLE
react-native-web compatibility

### DIFF
--- a/src/components/label/__snapshots__/test.js.snap
+++ b/src/components/label/__snapshots__/test.js.snap
@@ -12,14 +12,10 @@ exports[`renders active label 1`] = `
 >
   <Text
     accessible={true}
-    active={true}
     allowFontScaling={true}
-    animationDuration={225}
     collapsable={undefined}
     disabled={false}
     ellipsizeMode="tail"
-    errored={false}
-    focused={false}
     numberOfLines={1}
     style={
       Object {
@@ -45,14 +41,10 @@ exports[`renders errored label 1`] = `
 >
   <Text
     accessible={true}
-    active={false}
     allowFontScaling={true}
-    animationDuration={225}
     collapsable={undefined}
     disabled={false}
     ellipsizeMode="tail"
-    errored={true}
-    focused={false}
     numberOfLines={1}
     style={
       Object {
@@ -78,14 +70,10 @@ exports[`renders focused label 1`] = `
 >
   <Text
     accessible={true}
-    active={false}
     allowFontScaling={true}
-    animationDuration={225}
     collapsable={undefined}
     disabled={false}
     ellipsizeMode="tail"
-    errored={false}
-    focused={true}
     numberOfLines={1}
     style={
       Object {
@@ -111,14 +99,10 @@ exports[`renders label 1`] = `
 >
   <Text
     accessible={true}
-    active={false}
     allowFontScaling={true}
-    animationDuration={225}
     collapsable={undefined}
     disabled={false}
     ellipsizeMode="tail"
-    errored={false}
-    focused={false}
     numberOfLines={1}
     style={
       Object {
@@ -144,14 +128,10 @@ exports[`renders restricted label 1`] = `
 >
   <Text
     accessible={true}
-    active={false}
     allowFontScaling={true}
-    animationDuration={225}
     collapsable={undefined}
     disabled={false}
     ellipsizeMode="tail"
-    errored={false}
-    focused={false}
     numberOfLines={1}
     style={
       Object {

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -84,6 +84,10 @@ export default class Label extends PureComponent {
       baseSize,
       basePadding,
       style,
+      errored,
+      active, 
+      focused,
+      animationDuration,
       ...props
     } = this.props;
 


### PR DESCRIPTION
Prevents errors like "React does not recognize the `animationDuration` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `animationduration` instead. If you accidentally passed it from a parent component, remove it from the DOM element." when rendering in DOM.