### PR TITLE
added a prop to disable the default selectionColor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ class Example extends Component {
  onChangeText          | Change text callback                        | Function | -
  onFocus               | Focus callback                              | Function | -
  onBlur                | Blur callback                               | Function | -
+ disableSelectionColor | Disable the default selectionColor                              | Function | -
 
 Other [TextInput][rn-textinput] properties will also work
 

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -90,6 +90,8 @@ export default class TextField extends PureComponent {
     prefix: PropTypes.string,
     suffix: PropTypes.string,
 
+    disableSelectionColor: PropTypes.bool,
+
     containerStyle: (ViewPropTypes || View.propTypes).style,
     inputContainerStyle: (ViewPropTypes || View.propTypes).style,
   };
@@ -500,6 +502,12 @@ export default class TextField extends PureComponent {
       style: titleTextStyle,
     };
 
+    const defaultProps = {};
+
+    if (!props.disableSelectionColor) {
+        defaultProps.selectionColor = tintColor;
+    }
+
     return (
       <View {...containerProps}>
         <Animated.View {...inputContainerProps}>
@@ -512,8 +520,8 @@ export default class TextField extends PureComponent {
 
             <TextInput
               style={[styles.input, inputStyle, inputStyleOverrides]}
-              selectionColor={tintColor}
 
+              {...defaultProps}
               {...props}
 
               editable={!disabled && editable}


### PR DESCRIPTION
Hey,

First thanks for this great library, it served me well!
Due the the following (and very sad) exception produced in a detached Expo project, I had to disable the default `selectionColor` totally.
I added a `disableSelectionColor` prop that removes this prop on demand, and by that prevents this annoying issue.