### PR TITLE
Change prefix and suffix PropTypes from text to node

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -88,8 +88,8 @@ export default class TextField extends PureComponent {
 
     renderAccessory: PropTypes.func,
 
-    prefix: PropTypes.string,
-    suffix: PropTypes.string,
+    prefix: PropTypes.node,
+    suffix: PropTypes.node,
 
     containerStyle: (ViewPropTypes || View.propTypes).style,
     inputContainerStyle: (ViewPropTypes || View.propTypes).style,


### PR DESCRIPTION
This would allow any renderable prop type to be passed to `prefix` and `suffix` props which makes it possible to do something like this:

```javascript
import React, { Component } from 'react';
import Icon from 'react-native-vector-icons/FontAwesome';
import { TextField } from 'react-native-material-textfield';

class Example extends Component {
  state = {
    phone: '',
  };

  render() {
    let { phone } = this.state;

    return (
      <TextField
        label='Phone number'
        value={phone}
        onChangeText={ (phone) => this.setState({ phone }) }
        prefix={ <Icon name="rocket" size={30} color="#900" /> } 
      />
    );
  }
}
```