### PR TITLE
Implements native driver support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ class Example extends Component {
  errorColor            | Text field color for errored state          |   String | rgb(213, 0, 0)
  disabledLineType      | Text field line type in disabled state      |   String | dotted
  animationDuration     | Text field animation duration in ms         |   Number | 225
+ useNativeDriver       | Use Animated Native Driver were appliceable |  Boolean | true
  characterRestriction  | Text field soft limit for character counter |   Number | -
  disabled              | Text field availability                     |  Boolean | false
  editable              | Text field text can be edited               |  Boolean | true

--- a/src/components/field/__snapshots__/test.js.snap
+++ b/src/components/field/__snapshots__/test.js.snap
@@ -25,7 +25,11 @@ exports[`renders 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 36,
+          "transform": Array [
+            Object {
+              "translateY": 36,
+            },
+          ],
         }
       }
     >
@@ -189,7 +193,11 @@ exports[`renders accessory 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 36,
+          "transform": Array [
+            Object {
+              "translateY": 36,
+            },
+          ],
         }
       }
     >
@@ -365,7 +373,11 @@ exports[`renders counter 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 16,
+          "transform": Array [
+            Object {
+              "translateY": 16,
+            },
+          ],
         }
       }
     >
@@ -560,7 +572,11 @@ exports[`renders default value 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 16,
+          "transform": Array [
+            Object {
+              "translateY": 16,
+            },
+          ],
         }
       }
     >
@@ -742,7 +758,11 @@ exports[`renders disabled value 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 16,
+          "transform": Array [
+            Object {
+              "translateY": 16,
+            },
+          ],
         }
       }
     >
@@ -906,7 +926,11 @@ exports[`renders error 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 36,
+          "transform": Array [
+            Object {
+              "translateY": 36,
+            },
+          ],
         }
       }
     >
@@ -1073,7 +1097,11 @@ exports[`renders multiline value 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 16,
+          "transform": Array [
+            Object {
+              "translateY": 16,
+            },
+          ],
         }
       }
     >
@@ -1239,7 +1267,11 @@ exports[`renders prefix 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 16,
+          "transform": Array [
+            Object {
+              "translateY": 16,
+            },
+          ],
         }
       }
     >
@@ -1433,7 +1465,11 @@ exports[`renders restriction 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 16,
+          "transform": Array [
+            Object {
+              "translateY": 16,
+            },
+          ],
         }
       }
     >
@@ -1628,7 +1664,11 @@ exports[`renders suffix 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 16,
+          "transform": Array [
+            Object {
+              "translateY": 16,
+            },
+          ],
         }
       }
     >
@@ -1822,7 +1862,11 @@ exports[`renders title 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 36,
+          "transform": Array [
+            Object {
+              "translateY": 36,
+            },
+          ],
         }
       }
     >
@@ -1988,7 +2032,11 @@ exports[`renders value 1`] = `
       style={
         Object {
           "position": "absolute",
-          "top": 16,
+          "transform": Array [
+            Object {
+              "translateY": 16,
+            },
+          ],
         }
       }
     >

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -29,6 +29,7 @@ export default class TextField extends PureComponent {
     editable: true,
 
     animationDuration: 225,
+    useNativeDriver: true,
 
     fontSize: 16,
     titleFontSize: 12,
@@ -55,6 +56,7 @@ export default class TextField extends PureComponent {
     ...TextInput.propTypes,
 
     animationDuration: PropTypes.number,
+    useNativeDriver: PropTypes.bool,
 
     fontSize: PropTypes.number,
     titleFontSize: PropTypes.number,
@@ -335,6 +337,7 @@ export default class TextField extends PureComponent {
       disabledLineType,
       disabledLineWidth,
       animationDuration,
+      useNativeDriver,
       fontSize,
       titleFontSize,
       labelFontSize,
@@ -490,6 +493,7 @@ export default class TextField extends PureComponent {
       baseColor,
       errorColor,
       animationDuration,
+      useNativeDriver,
       active,
       focused,
       errored,

--- a/src/components/label/__snapshots__/test.js.snap
+++ b/src/components/label/__snapshots__/test.js.snap
@@ -6,7 +6,11 @@ exports[`renders active label 1`] = `
   style={
     Object {
       "position": "absolute",
-      "top": 16,
+      "transform": Array [
+        Object {
+          "translateY": 16,
+        },
+      ],
     }
   }
 >
@@ -34,7 +38,11 @@ exports[`renders errored label 1`] = `
   style={
     Object {
       "position": "absolute",
-      "top": 36,
+      "transform": Array [
+        Object {
+          "translateY": 36,
+        },
+      ],
     }
   }
 >
@@ -62,7 +70,11 @@ exports[`renders focused label 1`] = `
   style={
     Object {
       "position": "absolute",
-      "top": 16,
+      "transform": Array [
+        Object {
+          "translateY": 16,
+        },
+      ],
     }
   }
 >
@@ -90,7 +102,11 @@ exports[`renders label 1`] = `
   style={
     Object {
       "position": "absolute",
-      "top": 36,
+      "transform": Array [
+        Object {
+          "translateY": 36,
+        },
+      ],
     }
   }
 >
@@ -118,7 +134,11 @@ exports[`renders restricted label 1`] = `
   style={
     Object {
       "position": "absolute",
-      "top": 36,
+      "transform": Array [
+        Object {
+          "translateY": 36,
+        },
+      ],
     }
   }
 >

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -28,6 +28,7 @@ export default class Label extends PureComponent {
     errorColor: PropTypes.string.isRequired,
 
     animationDuration: PropTypes.number.isRequired,
+    useNativeDriver: PropTypes.bool,
 
     style: Animated.Text.propTypes.style,
 
@@ -48,13 +49,13 @@ export default class Label extends PureComponent {
 
   componentWillReceiveProps(props) {
     let { focus, input } = this.state;
-    let { active, focused, errored, animationDuration: duration } = this.props;
+    let { active, focused, errored, animationDuration: duration, useNativeDriver } = this.props;
 
     if (focused ^ props.focused || active ^ props.active) {
       let toValue = this.inputState(props);
 
       Animated
-        .timing(input, { toValue, duration })
+        .timing(input, { toValue, duration, useNativeDriver })
         .start();
     }
 
@@ -62,7 +63,7 @@ export default class Label extends PureComponent {
       let toValue = this.focusState(props);
 
       Animated
-        .timing(focus, { toValue, duration })
+        .timing(focus, { toValue, duration, useNativeDriver })
         .start();
     }
   }
@@ -92,6 +93,7 @@ export default class Label extends PureComponent {
       active, 
       focused,
       animationDuration,
+      useNativeDriver,
       ...props
     } = this.props;
 
@@ -102,7 +104,7 @@ export default class Label extends PureComponent {
         outputRange: [errorColor, baseColor, tintColor],
       });
 
-    let top = input.interpolate({
+    let translateY = input.interpolate({
       inputRange: [0, 1],
       outputRange: [
         baseSize + fontSize * 0.25,
@@ -121,7 +123,9 @@ export default class Label extends PureComponent {
 
     let containerStyle = {
       position: 'absolute',
-      top,
+      transform: [
+        { translateY },
+      ],
     };
 
     return (


### PR DESCRIPTION
First, thanks for this awesome little textfield thing, we love it! ❤️

One paint point that has become more obvious now when we implemented proper android support for our app is that our textfields can be a tad sluggish. 

This PR slightly changes how we animate the title once the textfield is focused. Rather than relying on `top` attribute, we now use `transform: [{translateY}]` to get the same functionality but with the perk of being able to use native drivers, running animation on the GPU thread instead. 🎉

Would appreciate if peepz could validate it works as intended since I might have missed some edge cases.

