### PR TITLE
Allow label styles to override everything

### DIFF
--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -126,7 +126,7 @@ export default class Label extends PureComponent {
 
     return (
       <Animated.View style={containerStyle}>
-        <Animated.Text style={[style, textStyle]} {...props}>
+        <Animated.Text style={[textStyle, style]} {...props}>
           {children}
         </Animated.Text>
       </Animated.View>


### PR DESCRIPTION
This style order makes more sense because it is now possible to override all the styles. For example customising the color was not possible before.