### PR TITLE
Use text elements in label, error fields

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -71,12 +71,18 @@ export default class TextField extends PureComponent {
     textColor: PropTypes.string,
     baseColor: PropTypes.string,
 
-    label: PropTypes.string.isRequired,
+    label: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]).isRequired,
     title: PropTypes.string,
 
     characterRestriction: PropTypes.number,
 
-    error: PropTypes.string,
+    error: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]),
     errorColor: PropTypes.string,
 
     lineWidth: PropTypes.number,


### PR DESCRIPTION
Fix propTypes to label, error to allow usage React elements.
It need for example, when you passed Intl FormattedMessage to this props!