### PR TITLE
Allow the Label text to change color during animation (using baseCor and tintColor props)

### DIFF
--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -89,7 +89,7 @@ export default class Label extends PureComponent {
       basePadding,
       style,
       errored,
-      active, 
+      active,
       focused,
       animationDuration,
       ...props
@@ -116,7 +116,10 @@ export default class Label extends PureComponent {
         outputRange: [fontSize, activeFontSize],
       }),
 
-      color,
+      color: input.interpolate({
+        inputRange: [0, 1],
+        outputRange: [baseColor, tintColor],
+      }),
     };
 
     let containerStyle = {


### PR DESCRIPTION
This change allows the user to change the Label text color between the animated states using the baseColor and tintColor props.  
  
This addresses issue found:
1) https://github.com/n4kz/react-native-material-dropdown/issues/6
2) https://github.com/n4kz/react-native-material-dropdown/issues/110