### PR TITLE
Helper Component extra Props missing

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -348,6 +348,7 @@ export default class TextField extends PureComponent {
       textColor,
       errorColor,
       lineWidth,
+      helperProps,
       activeLineWidth,
       containerStyle,
       inputContainerStyle: inputContainerStyleOverrides,
@@ -539,8 +540,8 @@ export default class TextField extends PureComponent {
 
         <Animated.View style={helperContainerStyle}>
           <View style={styles.flex}>
-            <Helper style={[errorStyle, titleTextStyle]}>{error}</Helper>
-            <Helper style={[titleStyle, titleTextStyle]}>{title}</Helper>
+            <Helper style={[errorStyle, titleTextStyle]} {...helperProps}>{error}</Helper>
+            <Helper style={[titleStyle, titleTextStyle]} {...helperProps}>{title}</Helper>
           </View>
 
           <Counter {...counterProps} />


### PR DESCRIPTION
The helper component in the field does not have the ability to give custom user defined props to the title/error field. Added the corresponding custom ability to the component so that the animated.text in helper component can accept props for it from the field component.