### PR TITLE
do not present defaultValues as placeholders / disabled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,6 @@
 
 Material texfield with consistent behaviour on iOS and Android
 
-![example][example-url]
-
 ## Features
 
 * Material design [guidelines][md-textfield] compliance

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,4 @@
-[npm-badge]: https://img.shields.io/npm/v/react-native-material-textfield.svg?colorB=ff6d00
-[npm-url]: https://npmjs.com/package/react-native-material-textfield
-[license-badge]: https://img.shields.io/npm/l/react-native-material-textfield.svg?colorB=448aff
-[license-url]: https://raw.githubusercontent.com/n4kz/react-native-material-textfield/master/license.txt
-[travis-badge]: https://api.travis-ci.org/n4kz/react-native-material-textfield.svg?branch=master
-[travis-url]: https://travis-ci.org/n4kz/react-native-material-textfield?branch=master
-[codeclimate-badge]: https://img.shields.io/codeclimate/maintainability/n4kz/react-native-material-textfield.svg
-[codeclimate-url]: https://codeclimate.com/github/n4kz/react-native-material-textfield
-[example-url]: https://cloud.githubusercontent.com/assets/2055622/24325711/eaa4ff08-11af-11e7-8550-2504c1580979.gif
-[rn-textinput]: https://facebook.github.io/react-native/docs/textinput.html#props
-[md-textfield]: https://material.io/guidelines/components/text-fields.html
-
 # react-native-material-textfield
-
-[![npm][npm-badge]][npm-url]
-[![license][license-badge]][license-url]
-[![travis][travis-badge]][travis-url]
-[![codeclimate][codeclimate-badge]][codeclimate-url]
 
 Material texfield with consistent behaviour on iOS and Android
 
@@ -41,7 +24,7 @@ Material texfield with consistent behaviour on iOS and Android
 ## Installation
 
 ```bash
-npm install --save react-native-material-textfield
+npm install --save https://github.com/shamilovtim/react-native-material-textfield-v3
 ```
 
 ## Usage
@@ -159,7 +142,7 @@ Other [TextInput][rn-textinput] properties will also work.
 ## Example
 
 ```bash
-git clone https://github.com/n4kz/react-native-material-textfield
+git clone https://github.com/shamilovtim/react-native-material-textfield-v3
 cd react-native-material-textfield/example
 npm install
 npm run ios # or npm run android

--- a/src/components/affix/index.js
+++ b/src/components/affix/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated, Text } from 'react-native';
 
 import styles from './styles';
 
@@ -11,7 +11,7 @@ export default class Affix extends PureComponent {
 
   static propTypes = {
     numberOfLines: PropTypes.number,
-    style: Animated.Text.propTypes.style,
+    style: Text.propType,
 
     color: PropTypes.string.isRequired,
     fontSize: PropTypes.number.isRequired,

--- a/src/components/affix/index.js
+++ b/src/components/affix/index.js
@@ -11,7 +11,7 @@ export default class Affix extends PureComponent {
 
   static propTypes = {
     numberOfLines: PropTypes.number,
-    style: Text.propType,
+    style: Text.propTypes,
 
     color: PropTypes.string.isRequired,
     fontSize: PropTypes.number.isRequired,

--- a/src/components/affix/index.js
+++ b/src/components/affix/index.js
@@ -11,8 +11,6 @@ export default class Affix extends PureComponent {
 
   static propTypes = {
     numberOfLines: PropTypes.number,
-    style: Text.propTypes,
-
     color: PropTypes.string.isRequired,
     fontSize: PropTypes.number.isRequired,
 

--- a/src/components/counter/index.js
+++ b/src/components/counter/index.js
@@ -11,8 +11,6 @@ export default class Counter extends PureComponent {
 
     baseColor: PropTypes.string.isRequired,
     errorColor: PropTypes.string.isRequired,
-
-    style: Text.propTypes.style,
   };
 
   render() {

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -468,7 +468,7 @@ export default class TextField extends PureComponent {
   inputStyle() {
     let { fontSize, baseColor, textColor, disabled, multiline } = this.props;
 
-    let color = disabled || this.isDefaultVisible()?
+    let color = disabled ?
       baseColor:
       textColor;
 

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
+import PropTypes from "prop-types";
+import React, { PureComponent } from "react";
 import {
   View,
   Text,
@@ -8,20 +8,18 @@ import {
   StyleSheet,
   Platform,
   ViewPropTypes,
-} from 'react-native';
+} from "react-native";
 
-import Line from '../line';
-import Label from '../label';
-import Affix from '../affix';
-import Helper from '../helper';
-import Counter from '../counter';
+import Line from "../line";
+import Label from "../label";
+import Affix from "../affix";
+import Helper from "../helper";
+import Counter from "../counter";
 
-import styles from './styles';
+import styles from "./styles";
 
 function startAnimation(animation, options, callback) {
-  Animated
-    .timing(animation, options)
-    .start(callback);
+  Animated.timing(animation, options).start(callback);
 }
 
 function labelStateFromProps(props, state) {
@@ -39,9 +37,9 @@ function errorStateFromProps(props, state) {
 
 export default class TextField extends PureComponent {
   static defaultProps = {
-    underlineColorAndroid: 'transparent',
+    underlineColorAndroid: "transparent",
     disableFullscreenUI: true,
-    autoCapitalize: 'sentences',
+    autoCapitalize: "sentences",
     editable: true,
 
     animationDuration: 225,
@@ -49,18 +47,18 @@ export default class TextField extends PureComponent {
     fontSize: 16,
     labelFontSize: 12,
 
-    tintColor: 'rgb(0, 145, 234)',
-    textColor: 'rgba(0, 0, 0, .87)',
-    baseColor: 'rgba(0, 0, 0, .38)',
+    tintColor: "rgb(0, 145, 234)",
+    textColor: "rgba(0, 0, 0, .87)",
+    baseColor: "rgba(0, 0, 0, .38)",
 
-    errorColor: 'rgb(213, 0, 0)',
+    errorColor: "rgb(213, 0, 0)",
 
     lineWidth: StyleSheet.hairlineWidth,
     activeLineWidth: 2,
     disabledLineWidth: 1,
 
-    lineType: 'solid',
-    disabledLineType: 'dotted',
+    lineType: "solid",
+    disabledLineType: "dotted",
 
     disabled: false,
   };
@@ -159,8 +157,8 @@ export default class TextField extends PureComponent {
     this.onContentSizeChange = this.onContentSizeChange.bind(this);
     this.onFocusAnimationEnd = this.onFocusAnimationEnd.bind(this);
 
-    this.createGetter('contentInset');
-    this.createGetter('labelOffset');
+    this.createGetter("contentInset");
+    this.createGetter("labelOffset");
 
     this.inputRef = React.createRef();
     this.mounted = false;
@@ -168,8 +166,8 @@ export default class TextField extends PureComponent {
 
     let { value: text, error, fontSize } = this.props;
 
-    let labelState = labelStateFromProps(this.props, { text })? 1 : 0;
-    let focusState = errorStateFromProps(this.props)? -1 : 0;
+    let labelState = labelStateFromProps(this.props, { text }) ? 1 : 0;
+    let focusState = errorStateFromProps(this.props) ? -1 : 0;
 
     this.state = {
       text,
@@ -253,7 +251,7 @@ export default class TextField extends PureComponent {
       return -1;
     }
 
-    return this.focused? 1 : 0;
+    return this.focused ? 1 : 0;
   }
 
   labelState() {
@@ -261,7 +259,7 @@ export default class TextField extends PureComponent {
       return 1;
     }
 
-    return this.focused? 1 : 0;
+    return this.focused ? 1 : 0;
   }
 
   focus() {
@@ -285,24 +283,20 @@ export default class TextField extends PureComponent {
     input.clear();
 
     /* onChangeText is not triggered by .clear() */
-    this.onChangeText('');
+    this.onChangeText("");
   }
 
   value() {
     let { text } = this.state;
     let { defaultValue } = this.props;
 
-    let value = this.isDefaultVisible()?
-      defaultValue:
-      text;
+    let value = this.isDefaultVisible() ? defaultValue : text;
 
     if (null == value) {
-      return '';
+      return "";
     }
 
-    return 'string' === typeof value?
-      value:
-      String(value);
+    return "string" === typeof value ? value : String(value);
   }
 
   setValue(text) {
@@ -347,7 +341,7 @@ export default class TextField extends PureComponent {
     let { onFocus, clearTextOnFocus } = this.props;
     let { receivedFocus } = this.state;
 
-    if ('function' === typeof onFocus) {
+    if ("function" === typeof onFocus) {
       onFocus(event);
     }
 
@@ -368,7 +362,7 @@ export default class TextField extends PureComponent {
   onBlur(event) {
     let { onBlur } = this.props;
 
-    if ('function' === typeof onBlur) {
+    if ("function" === typeof onBlur) {
       onBlur(event);
     }
 
@@ -381,7 +375,7 @@ export default class TextField extends PureComponent {
   onChange(event) {
     let { onChange } = this.props;
 
-    if ('function' === typeof onChange) {
+    if ("function" === typeof onChange) {
       onChange(event);
     }
   }
@@ -389,13 +383,13 @@ export default class TextField extends PureComponent {
   onChangeText(text) {
     let { onChangeText, formatText } = this.props;
 
-    if ('function' === typeof formatText) {
+    if ("function" === typeof formatText) {
       text = formatText(text);
     }
 
     this.setState({ text });
 
-    if ('function' === typeof onChangeText) {
+    if ("function" === typeof onChangeText) {
       onChangeText(text);
     }
   }
@@ -404,7 +398,7 @@ export default class TextField extends PureComponent {
     let { onContentSizeChange, fontSize } = this.props;
     let { height } = event.nativeEvent.contentSize;
 
-    if ('function' === typeof onContentSizeChange) {
+    if ("function" === typeof onContentSizeChange) {
       onContentSizeChange(event);
     }
 
@@ -429,31 +423,31 @@ export default class TextField extends PureComponent {
     let { height: computedHeight } = this.state;
     let { multiline, fontSize, height = computedHeight } = this.props;
 
-    return multiline?
-      height:
-      fontSize * 1.5;
+    return multiline ? height : fontSize * 1.5;
   }
 
   inputContainerHeight() {
     let { labelFontSize, multiline } = this.props;
     let contentInset = this.contentInset();
 
-    if ('web' === Platform.OS && multiline) {
-      return 'auto';
+    if ("web" === Platform.OS && multiline) {
+      return "auto";
     }
 
-    return contentInset.top
-      + labelFontSize
-      + contentInset.label
-      + this.inputHeight()
-      + contentInset.input;
+    return (
+      contentInset.top +
+      labelFontSize +
+      contentInset.label +
+      this.inputHeight() +
+      contentInset.input
+    );
   }
 
   inputProps() {
     let store = {};
 
     for (let key in TextInput.propTypes) {
-      if ('defaultValue' === key) {
+      if ("defaultValue" === key) {
         continue;
       }
 
@@ -468,9 +462,7 @@ export default class TextField extends PureComponent {
   inputStyle() {
     let { fontSize, baseColor, textColor, disabled, multiline } = this.props;
 
-    let color = disabled ?
-      baseColor:
-      textColor;
+    let color = disabled ? baseColor : textColor;
 
     let style = {
       fontSize,
@@ -481,12 +473,14 @@ export default class TextField extends PureComponent {
 
     if (multiline) {
       let lineHeight = fontSize * 1.5;
-      let offset = 'ios' === Platform.OS? 2 : 0;
+      let offset = "ios" === Platform.OS ? 2 : 0;
 
       style.height += lineHeight;
-      style.transform = [{
-        translateY: lineHeight + offset,
-      }];
+      style.transform = [
+        {
+          translateY: lineHeight + offset,
+        },
+      ];
     }
 
     return style;
@@ -495,12 +489,7 @@ export default class TextField extends PureComponent {
   renderLabel(props) {
     let offset = this.labelOffset();
 
-    let {
-      label,
-      fontSize,
-      labelFontSize,
-      labelTextStyle,
-    } = this.props;
+    let { label, fontSize, labelFontSize, labelTextStyle } = this.props;
 
     return (
       <Label
@@ -515,17 +504,13 @@ export default class TextField extends PureComponent {
   }
 
   renderLine(props) {
-    return (
-      <Line {...props} />
-    );
+    return <Line {...props} />;
   }
 
   renderAccessory(prop) {
     let { [prop]: renderAccessory } = this.props;
 
-    return 'function' === typeof renderAccessory?
-      renderAccessory():
-      null;
+    return "function" === typeof renderAccessory ? renderAccessory() : null;
   }
 
   renderAffix(type) {
@@ -549,9 +534,7 @@ export default class TextField extends PureComponent {
       labelAnimation,
     };
 
-    return (
-      <Affix {...props}>{affix}</Affix>
-    );
+    return <Affix {...props}>{affix}</Affix>;
   }
 
   renderHelper() {
@@ -569,7 +552,7 @@ export default class TextField extends PureComponent {
     let { length: count } = this.value();
     let contentInset = this.contentInset();
 
-    let containerStyle =  {
+    let containerStyle = {
       paddingLeft: contentInset.left,
       paddingRight: contentInset.right,
       minHeight: contentInset.bottom,
@@ -617,9 +600,7 @@ export default class TextField extends PureComponent {
     return (
       <TextInput
         selectionColor={tintColor}
-
         {...props}
-
         style={[styles.input, inputStyle, inputStyleOverrides]}
         editable={!disabled && editable}
         onChange={this.onChange}
@@ -665,9 +646,7 @@ export default class TextField extends PureComponent {
       style: containerStyle,
       onStartShouldSetResponder: () => true,
       onResponderRelease: this.onPress,
-      pointerEvents: !disabled && editable?
-        'auto':
-        'none',
+      pointerEvents: !disabled && editable ? "auto" : "none",
     };
 
     let inputContainerProps = {
@@ -706,19 +685,19 @@ export default class TextField extends PureComponent {
       <View {...containerProps}>
         <Animated.View {...inputContainerProps}>
           {this.renderLine(lineProps)}
-          {this.renderAccessory('renderLeftAccessory')}
+          {this.renderAccessory("renderLeftAccessory")}
 
           <View style={styles.stack}>
             {this.renderLabel(styleProps)}
 
             <View style={styles.row}>
-              {this.renderAffix('prefix')}
+              {this.renderAffix("prefix")}
               {this.renderInput()}
-              {this.renderAffix('suffix')}
+              {this.renderAffix("suffix")}
             </View>
           </View>
 
-          {this.renderAccessory('renderRightAccessory')}
+          {this.renderAccessory("renderRightAccessory")}
         </Animated.View>
 
         {this.renderHelper()}

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -19,7 +19,8 @@ import Counter from "../counter";
 import styles from "./styles";
 
 function startAnimation(animation, options, callback) {
-  Animated.timing(animation, options).start(callback);
+  let withoutNativeDriver = {useNativeDriver: false, ...options};
+  Animated.timing(animation, withoutNativeDriver).start(callback);
 }
 
 function labelStateFromProps(props, state) {

--- a/src/components/helper/index.js
+++ b/src/components/helper/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated, Text } from 'react-native';
 
 import styles from './styles';
 
@@ -11,7 +11,7 @@ export default class Helper extends PureComponent {
 
     disabled: PropTypes.bool,
 
-    style: Animated.Text.propTypes.style,
+    style: Text.propType,
 
     baseColor: PropTypes.string,
     errorColor: PropTypes.string,

--- a/src/components/helper/index.js
+++ b/src/components/helper/index.js
@@ -11,8 +11,6 @@ export default class Helper extends PureComponent {
 
     disabled: PropTypes.bool,
 
-    style: Text.propTypes,
-
     baseColor: PropTypes.string,
     errorColor: PropTypes.string,
 

--- a/src/components/helper/index.js
+++ b/src/components/helper/index.js
@@ -11,7 +11,7 @@ export default class Helper extends PureComponent {
 
     disabled: PropTypes.bool,
 
-    style: Text.propType,
+    style: Text.propTypes,
 
     baseColor: PropTypes.string,
     errorColor: PropTypes.string,

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated, Text } from 'react-native';
 
 import styles from './styles';
 
@@ -43,7 +43,7 @@ export default class Label extends PureComponent {
       y1: PropTypes.number,
     }),
 
-    style: Animated.Text.propTypes.style,
+    style: Text.propType,
     label: PropTypes.string,
   };
 

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -43,7 +43,6 @@ export default class Label extends PureComponent {
       y1: PropTypes.number,
     }),
 
-    style: Text.propTypes,
     label: PropTypes.string,
   };
 

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -43,7 +43,7 @@ export default class Label extends PureComponent {
       y1: PropTypes.number,
     }),
 
-    style: Text.propType,
+    style: Text.propTypes,
     label: PropTypes.string,
   };
 


### PR DESCRIPTION
defaultvalues are currently being presented as a placeholder. a defaultValue is still a value. this violates material design guidelines and is confusing to users. 

PR stops this from happening and makes defaultValue look just like a value

fixes #191