### PR TITLE
remove non existing property from the API docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,6 @@ class Example extends Component {
  titleTextStyle        | Style for title inner Text component        |   Object | -
  affixTextStyle        | Style for affix inner Text component        |   Object | -
  formatText            | Input mask callback                         | Function | -
- renderLeftAccessory   | Render left input accessory view            | Function | -
  renderRightAccessory  | Render right input accessory view           | Function | -
  onChangeText          | Change text callback                        | Function | -
  onFocus               | Focus callback                              | Function | -


### PR DESCRIPTION
I was trying to use it since i saw it in the docs, but when i looked in the source code, i saw it was removed. I used `Prefix` instead as i only wanted to display text.