### PR TITLE
Add useNativeDriver to startFocusAnimation

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -223,6 +223,7 @@ export default class TextField extends PureComponent {
 
     let options = {
       toValue: this.focusState(),
+      useNativeDriver: false,
       duration,
     };
 


### PR DESCRIPTION
It introduces `useNativeDriver` flag to the `Animated.timing` options in `startFocusAnimation` method to prevent displaying the warning.

> WARN Animated: "useNativeDriver" was not specified. This is a required option and must be explicitly set to "true" or "false".
