### PR TITLE
Remove propTypes from Animated components in Version 0.62

### DIFF
--- a/src/components/affix/index.js
+++ b/src/components/affix/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated,ViewPropTypes } from 'react-native';
 
 import styles from './styles';
 
@@ -11,7 +11,7 @@ export default class Affix extends PureComponent {
 
   static propTypes = {
     numberOfLines: PropTypes.number,
-    style: Animated.Text.propTypes.style,
+    style: ViewPropTypes.style,
 
     color: PropTypes.string.isRequired,
     fontSize: PropTypes.number.isRequired,

--- a/src/components/affix/index.js
+++ b/src/components/affix/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated,ViewPropTypes } from 'react-native';
+import { Animated, ViewPropTypes } from 'react-native';
 
 import styles from './styles';
 

--- a/src/components/helper/index.js
+++ b/src/components/helper/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated,ViewPropTypes } from 'react-native';
 
 import styles from './styles';
 
@@ -11,7 +11,7 @@ export default class Helper extends PureComponent {
 
     disabled: PropTypes.bool,
 
-    style: Animated.Text.propTypes.style,
+    style: ViewPropTypes.style,
 
     baseColor: PropTypes.string,
     errorColor: PropTypes.string,

--- a/src/components/helper/index.js
+++ b/src/components/helper/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated,ViewPropTypes } from 'react-native';
+import { Animated, ViewPropTypes } from 'react-native';
 
 import styles from './styles';
 

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated,ViewPropTypes } from 'react-native';
+import { Animated, ViewPropTypes } from 'react-native';
 
 import styles from './styles';
 

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Animated,ViewPropTypes } from 'react-native';
 
 import styles from './styles';
 
@@ -43,7 +43,7 @@ export default class Label extends PureComponent {
       y1: PropTypes.number,
     }),
 
-    style: Animated.Text.propTypes.style,
+    style: ViewPropTypes.style,
     label: PropTypes.string,
   };
 


### PR DESCRIPTION
Remove propTypes from Animated components. (86d90c03eb by @yungsters)

source : https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#v0622