### PR TITLE
fix maxLineWidth:

### DIFF
--- a/src/components/line/index.js
+++ b/src/components/line/index.js
@@ -44,7 +44,7 @@ export default class Line extends PureComponent {
       1,
     );
 
-    if (maxLineWidth !== state.maxLineWidth) {
+    if (maxLineWidth && maxLineWidth !== state.maxLineWidth) {
       return { maxLineWidth };
     }
 


### PR DESCRIPTION
maxLineWidth is NaN if any line width props has not been set, it cause the error below:
Invariant Violation: [...{"top":"<<NaN>>", "right":"<<NaN>>", "left":"<<NaN>>"}] is not usable as a native method argument


![image](https://user-images.githubusercontent.com/24285778/91254444-a5200c00-e78c-11ea-8e4e-f525eae41ad5.png)
