### PR TITLE
contentInset.left adds extra space

### DIFF
--- a/src/components/outline/index.js
+++ b/src/components/outline/index.js
@@ -85,7 +85,7 @@ export default class Line extends PureComponent {
       return null;
     }
 
-    let labelOffset = 2 * (contentInset.left - 2 * borderRadius);
+    let labelOffset = 2 * borderRadius;
     let lineOffset = Animated.add(labelWidth, labelOffset);
 
     let topLineContainerStyle = {


### PR DESCRIPTION
This would remove the added extra space after the label if contentInset.left is given a positive number