### PR TITLE
Adds prop inputStyle

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -466,13 +466,14 @@ export default class TextField extends PureComponent {
   }
 
   inputStyle() {
-    let { fontSize, baseColor, textColor, disabled, multiline } = this.props;
+    let { fontSize, baseColor, textColor, disabled, multiline, inputStyle } = this.props;
 
     let color = disabled || this.isDefaultVisible()?
       baseColor:
       textColor;
 
     let style = {
+      ...inputStyle,
       fontSize,
       color,
 


### PR DESCRIPTION
inputStyle is spread first, allowing the fixed props of fontSize, baseColor, textColor, disabled, multiline to override
This allows for all TextStyleProps to be supported (e.g. textAlign) by the TextInput componant.
using textAlign as an example: it's determined by I18nManager in styles. This PR allows flexibility for a non-RTL environment to include textAlign: 'right' fields (useful for currency and accounting)