### PR TITLE
fix: TextField with multiline enabled does not scroll up as text line increases

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -480,12 +480,10 @@ export default class TextField extends PureComponent {
     };
 
     if (multiline) {
-      let lineHeight = fontSize * 1.5;
       let offset = 'ios' === Platform.OS? 2 : 0;
 
-      style.height += lineHeight;
       style.transform = [{
-        translateY: lineHeight + offset,
+        translateY: offset,
       }];
     }
 


### PR DESCRIPTION
![Screenshot 2021-04-16 at 7 09 42 PM](https://user-images.githubusercontent.com/17010140/115036934-62f83600-9ee7-11eb-91fd-61de3fe20d40.png)
